### PR TITLE
fix for singularity --home, move qc to datatype

### DIFF
--- a/snakedwi/workflow/Snakefile
+++ b/snakedwi/workflow/Snakefile
@@ -21,13 +21,13 @@ rule all:
         **get_eddy_quad_all(),
         **get_bedpost_all(),
         mask_qc=expand(
-            bids(root="qc", suffix="mask.png", desc="brain", **subj_wildcards),
+            bids(root=root,datatype='qc', suffix="mask.png", desc="brain", **subj_wildcards),
             zip,
             **input_zip_lists["dwi"]
         ),
         reg_qc=expand(
             bids(
-                root="qc", suffix="reg.png", from_="dwiref", to="T1w", **subj_wildcards
+                root=root,datatype='qc', suffix="reg.png", from_="dwiref", to="T1w", **subj_wildcards
             ),
             zip,
             **input_zip_lists["dwi"]

--- a/snakedwi/workflow/Snakefile
+++ b/snakedwi/workflow/Snakefile
@@ -21,13 +21,24 @@ rule all:
         **get_eddy_quad_all(),
         **get_bedpost_all(),
         mask_qc=expand(
-            bids(root=root,datatype='qc', suffix="mask.png", desc="brain", **subj_wildcards),
+            bids(
+                root=root,
+                datatype="qc",
+                suffix="mask.png",
+                desc="brain",
+                **subj_wildcards
+            ),
             zip,
             **input_zip_lists["dwi"]
         ),
         reg_qc=expand(
             bids(
-                root=root,datatype='qc', suffix="reg.png", from_="dwiref", to="T1w", **subj_wildcards
+                root=root,
+                datatype="qc",
+                suffix="reg.png",
+                from_="dwiref",
+                to="T1w",
+                **subj_wildcards
             ),
             zip,
             **input_zip_lists["dwi"]

--- a/snakedwi/workflow/rules/prepdwi.smk
+++ b/snakedwi/workflow/rules/prepdwi.smk
@@ -718,13 +718,12 @@ rule qc_brainmask_for_eddy:
         ),
         seg=get_mask_for_eddy(),
     output:
-        #        png = bids(root='qc',subject='{subject}',suffix='mask.png',desc='brain'),
         png=report(
-            bids(root="qc", suffix="mask.png", desc="brain", **subj_wildcards),
+            bids(root=root,datatype='qc', suffix="mask.png", desc="brain", **subj_wildcards),
             caption="../report/brainmask_dwi.rst",
             category="Brainmask",
         ),
-        html=bids(root="qc", suffix="mask.html", desc="brain", **subj_wildcards),
+        html=bids(root=root,datatype='qc', suffix="mask.html", desc="brain", **subj_wildcards),
     group:
         "subj"
     container:

--- a/snakedwi/workflow/rules/prepdwi.smk
+++ b/snakedwi/workflow/rules/prepdwi.smk
@@ -719,11 +719,23 @@ rule qc_brainmask_for_eddy:
         seg=get_mask_for_eddy(),
     output:
         png=report(
-            bids(root=root,datatype='qc', suffix="mask.png", desc="brain", **subj_wildcards),
+            bids(
+                root=root,
+                datatype="qc",
+                suffix="mask.png",
+                desc="brain",
+                **subj_wildcards
+            ),
             caption="../report/brainmask_dwi.rst",
             category="Brainmask",
         ),
-        html=bids(root=root,datatype='qc', suffix="mask.html", desc="brain", **subj_wildcards),
+        html=bids(
+            root=root,
+            datatype="qc",
+            suffix="mask.html",
+            desc="brain",
+            **subj_wildcards
+        ),
     group:
         "subj"
     container:

--- a/snakedwi/workflow/rules/prepdwi.smk
+++ b/snakedwi/workflow/rules/prepdwi.smk
@@ -984,12 +984,10 @@ if config["use_eddy_gpu"]:
             gpus=1,
             time=360,  #6 hours (this is a conservative estimate, may be shorter)
             mem_mb=32000,
-        log:
-            bids(root="logs", suffix="run_eddy_gpu.log", **subj_wildcards),
         group:
             "subj"
         shell:
-            "singularity exec --nv -e {params.container} eddy_cuda9.1 "
+            "singularity exec --nv --home $PWD -e {params.container} eddy_cuda9.1 "
             " --imain={input.dwi_concat} --mask={input.brainmask} "
             " --acqp={input.phenc_concat} --index={input.eddy_index_txt} "
             " --bvecs={input.bvecs} --bvals={input.bvals} "
@@ -997,7 +995,7 @@ if config["use_eddy_gpu"]:
             " {params.s2v_opts} "
             " {params.slspec_opt} "
             " {params.topup_opt} "
-            " {params.flags}  &> {log}"
+            " {params.flags}"
 
 
 else:
@@ -1401,7 +1399,7 @@ if config["use_bedpost_gpu"]:
         shell:
             #remove the logs to reduce # of files  
             # remove the input dir (copy of files) 
-            "singularity exec --nv -e {params.container} bedpostx_gpu {input.diff_dir} && "
+            "singularity exec --nv --home $PWD -e {params.container} bedpostx_gpu {input.diff_dir} && "
             "rm -rf {output.bedpost_dir}/logs "
 
 
@@ -1490,7 +1488,7 @@ else:
             mem_mb=16000,
             time=360,
         shell:
-            "singularity exec -B {params.parallel_script}:{params.parallel_script_container} -e "
+            "singularity exec --home $PWD -B {params.parallel_script}:{params.parallel_script_container} -e "
             " {params.container} {params.bedpost_script} {input.diff_dir} -P {threads} && "
             "rm -rf {output.bedpost_dir}/logs "
 

--- a/snakedwi/workflow/rules/reg_dwi_to_t1.smk
+++ b/snakedwi/workflow/rules/reg_dwi_to_t1.smk
@@ -103,13 +103,23 @@ rule qc_reg_dwi_t1:
     output:
         png=report(
             bids(
-                root=root,datatype='qc', suffix="reg.png", **subj_wildcards, from_="dwiref", to="T1w"
+                root=root,
+                datatype="qc",
+                suffix="reg.png",
+                **subj_wildcards,
+                from_="dwiref",
+                to="T1w"
             ),
             caption="../report/reg_dwi_t1.rst",
             category="B0 T1w registration",
         ),
         html=bids(
-            root=root,datatype='qc', suffix="reg.html", from_="dwiref", to="T1w", **subj_wildcards
+            root=root,
+            datatype="qc",
+            suffix="reg.html",
+            from_="dwiref",
+            to="T1w",
+            **subj_wildcards
         ),
     group:
         "subj"

--- a/snakedwi/workflow/rules/reg_dwi_to_t1.smk
+++ b/snakedwi/workflow/rules/reg_dwi_to_t1.smk
@@ -103,13 +103,13 @@ rule qc_reg_dwi_t1:
     output:
         png=report(
             bids(
-                root="qc", suffix="reg.png", **subj_wildcards, from_="dwiref", to="T1w"
+                root=root,datatype='qc', suffix="reg.png", **subj_wildcards, from_="dwiref", to="T1w"
             ),
             caption="../report/reg_dwi_t1.rst",
             category="B0 T1w registration",
         ),
         html=bids(
-            root="qc", suffix="reg.html", from_="dwiref", to="T1w", **subj_wildcards
+            root=root,datatype='qc', suffix="reg.html", from_="dwiref", to="T1w", **subj_wildcards
         ),
     group:
         "subj"

--- a/snakedwi/workflow/rules/visqc.smk
+++ b/snakedwi/workflow/rules/visqc.smk
@@ -12,7 +12,8 @@ rule qc_reg:
     output:
         png=report(
             bids(
-                root=root,datatype='qc',
+                root=root,
+                datatype="qc",
                 subject="{subject}",
                 suffix="regqc.png",
                 from_="subject",
@@ -24,7 +25,8 @@ rule qc_reg:
             subcategory="{desc} {template}",
         ),
         html=bids(
-            root=root,datatype='qc',
+            root=root,
+            datatype="qc",
             subject="{subject}",
             suffix="regqc.html",
             from_="subject",
@@ -51,7 +53,8 @@ rule qc_probseg:
     output:
         png=report(
             bids(
-                root=root,datatype='qc',
+                root=root,
+                datatype="qc",
                 subject="{subject}",
                 suffix="probseg.png",
                 desc="atropos3seg",
@@ -82,7 +85,8 @@ rule qc_dseg:
     output:
         png=report(
             bids(
-                root=root,datatype='qc',
+                root=root,
+                datatype="qc",
                 subject="{subject}",
                 suffix="dseg.png",
                 atlas="{atlas}",
@@ -93,7 +97,8 @@ rule qc_dseg:
             subcategory="{atlas} Atlas from {template}",
         ),
         html=bids(
-            root=root,datatype='qc',
+            root=root,
+            datatype="qc",
             subject="{subject}",
             suffix="dseg.html",
             atlas="{atlas}",

--- a/snakedwi/workflow/rules/visqc.smk
+++ b/snakedwi/workflow/rules/visqc.smk
@@ -12,7 +12,7 @@ rule qc_reg:
     output:
         png=report(
             bids(
-                root="qc",
+                root=root,datatype='qc',
                 subject="{subject}",
                 suffix="regqc.png",
                 from_="subject",
@@ -24,7 +24,7 @@ rule qc_reg:
             subcategory="{desc} {template}",
         ),
         html=bids(
-            root="qc",
+            root=root,datatype='qc',
             subject="{subject}",
             suffix="regqc.html",
             from_="subject",
@@ -51,7 +51,7 @@ rule qc_probseg:
     output:
         png=report(
             bids(
-                root="qc",
+                root=root,datatype='qc',
                 subject="{subject}",
                 suffix="probseg.png",
                 desc="atropos3seg",
@@ -82,7 +82,7 @@ rule qc_dseg:
     output:
         png=report(
             bids(
-                root="qc",
+                root=root,datatype='qc',
                 subject="{subject}",
                 suffix="dseg.png",
                 atlas="{atlas}",
@@ -93,7 +93,7 @@ rule qc_dseg:
             subcategory="{atlas} Atlas from {template}",
         ),
         html=bids(
-            root="qc",
+            root=root,datatype='qc',
             subject="{subject}",
             suffix="dseg.html",
             atlas="{atlas}",


### PR DESCRIPTION
- adds `--home $PWD` to the custom singularity exec calls, was failing without this when trying to use SLURM_TMPDIR
   - note: snakemake uses --home $PWD with the container directive too
- move qc folder from root into subject/session folders by using it as a datatype instead