### PR TITLE
fixes earlier PR on get_phase_encode_txt that broke this

### DIFF
--- a/snakedwi/workflow/scripts/check_json_metadata.py
+++ b/snakedwi/workflow/scripts/check_json_metadata.py
@@ -22,16 +22,15 @@ for json_file in snakemake.input:
 
                 sys.exit(1)
 
-        if snakemake.config["no_topup"] == False:
+        # we need to have PhaseEncodingDirection even if top-up isn't used, since Eddy requires it
+        if "PhaseEncodingDirection" not in json_dwi:
+            print(f"ERROR: PhaseEncodingDirection not found in {json_file}")
+            print("You must do one of the following:")
+            print(" 1. add the PhaseEncodingDirection field to your dwi JSON files")
+            print(" 2. use the --no_topup option to disable top-up")
+            sys.exit(1)
 
-            if "PhaseEncodingDirection" not in json_dwi:
-                print(f"ERROR: PhaseEncodingDirection not found in {json_file}")
-                print("You must do one of the following:")
-                print(" 1. add the PhaseEncodingDirection field to your dwi JSON files")
-                print(" 2. use the --no_topup option to disable top-up")
-                sys.exit(1)
-
-            if "EffectiveEchoSpacing" not in json_dwi:
-                effechospc = snakemake.config["default_effective_echo_spacing"]
-                print(f"WARNING: EffectiveEchoSpacing not found in {json_file}")
-                print(f"If not defined, a default value of {effechospc} will be used")
+        if "EffectiveEchoSpacing" not in json_dwi:
+            effechospc = snakemake.config["default_effective_echo_spacing"]
+            print(f"WARNING: EffectiveEchoSpacing not found in {json_file}")
+            print(f"If not defined, a default value of {effechospc} will be used")

--- a/snakedwi/workflow/scripts/get_phase_encode_txt.py
+++ b/snakedwi/workflow/scripts/get_phase_encode_txt.py
@@ -17,6 +17,8 @@ imsize = np.array(bzero.header.get_data_shape())
 if "PhaseEncodingDirection" in json_dwi:
     phenc_axis = json_dwi["PhaseEncodingDirection"][0]
     phenc_string = "PhaseEncodingDirection"
+
+# NOTE: PhaseEncodingAxis doesn't encode + or -, so if this is used then you cannot use rev phase encoding distortion correction (but it can still be used if there is just a single scan)
 elif "PhaseEncodingAxis" in json_dwi:
     phenc_axis = json_dwi["PhaseEncodingAxis"][0]  # either i, j, k
     phenc_string = "PhaseEncodingAxis"
@@ -54,6 +56,10 @@ else:
     json_dwi["EffectiveEchoSpacing"] = snakemake.config[
         "default_effective_echo_spacing"
     ]
+    phenc_line = np.hstack(
+        [vec, np.array(json_dwi["EffectiveEchoSpacing"] * numPhaseEncodes)]
+    )
+
 
 # create the phenc_line row
 # phenc_line = np.hstack(
@@ -67,6 +73,7 @@ else:
     phenc_data = np.column_stack(phenc_line)
     # need to column_stack so that it becomes 2d array
     # otherwwise savetxt will always save 1d array as column..
+
 
 # save to txt
 np.savetxt(snakemake.output.phenc_txt, phenc_data, fmt="%.5f")


### PR DESCRIPTION
This fixes a bug introduced in #31, was not dealing with the default effective echo spacing properly