### PR TITLE
change default iters for reg_dwi_to_t1, add cli opt

### DIFF
--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -145,6 +145,11 @@ parse_args:
       - 'image-centers'
     default: 'identity'
 
+  --rigid_dwi_t1_iters:
+    help: 'Number of iterations to use at each multi-resolution stage for dwi to t1 rigid registration. (default: %(default)s)'
+    default: '50x50'
+
+
 
 
 #---- to update below this

--- a/snakedwi/workflow/rules/reg_dwi_to_t1.smk
+++ b/snakedwi/workflow/rules/reg_dwi_to_t1.smk
@@ -52,8 +52,9 @@ rule reg_dwi_to_t1:
         ),
     params:
         general_opts="-d 3",
-        rigid_opts="-m NMI -a -dof 6 -ia-{rigid_dwi_t1_init}".format(
-            rigid_dwi_t1_init=config["rigid_dwi_t1_init"]
+        rigid_opts="-m NMI -a -dof 6 -ia-{rigid_dwi_t1_init} -n {rigid_dwi_t1_iters}".format(
+            rigid_dwi_t1_init=config["rigid_dwi_t1_init"],
+            rigid_dwi_t1_iters=config["rigid_dwi_t1_iters"],
         ),
     output:
         warped_avgb0=bids(


### PR DESCRIPTION
should improve dwi to t1 rigid registration accuracy and robustness

closes #41 