### PR TITLE
Implement mrview based qc image generation

### DIFF
--- a/snakedwi/workflow/Snakefile
+++ b/snakedwi/workflow/Snakefile
@@ -30,7 +30,7 @@ rule all:
             bids(
                 root=root,
                 datatype="qc",
-                suffix="mask.png",
+                suffix="mask",
                 desc="brain",
                 **subj_wildcards
             ),
@@ -41,7 +41,7 @@ rule all:
             bids(
                 root=root,
                 datatype="qc",
-                suffix="reg.png",
+                suffix="reg",
                 from_="dwiref",
                 to="T1w",
                 **subj_wildcards

--- a/snakedwi/workflow/rules/prepdwi.smk
+++ b/snakedwi/workflow/rules/prepdwi.smk
@@ -492,6 +492,7 @@ def get_b0_mask():
     )
 
 
+
 # generate qc snapshot for brain  mask
 rule qc_b0_brainmask:
     input:
@@ -504,27 +505,26 @@ rule qc_b0_brainmask:
         ),
         seg=get_b0_mask(),
     output:
-        png=report(
-            bids(
-                root=root,
-                datatype="qc",
-                suffix="mask.png",
-                desc="brain",
-                **subj_wildcards
-            ),
-            caption="../report/brainmask_dwi.rst",
-            category="Brainmask",
-        ),
-        html=bids(
+        pics=directory(bids(
             root=root,
             datatype="qc",
-            suffix="mask.html",
+            suffix="mask",
             desc="brain",
-            **subj_wildcards
-        ),
+            **subj_wildcards,
+        ))
     group:
         "subj"
     container:
         config["singularity"]["python"]
     script:
         "../scripts/vis_qc_dseg.py"
+    envmodules:
+        "mrtrix/3.0.1"
+    shell:
+        "mkdir -p {output.pics} && "
+
+        "xvfb-run -a bash -c 'mrview {input.img} -overlay.load {input.seg} "
+        "-overlay.opacity 0.3 -overlay.threshold_min 0 -noannotations "
+        "-overlay.interpolation false -overlay.colour 255,0,0 "
+        "-capture.folder {output.pics} "
+        "$(../scripts/mrview_capture {input.img}) -exit'"

--- a/snakedwi/workflow/rules/reg_dwi_to_t1.smk
+++ b/snakedwi/workflow/rules/reg_dwi_to_t1.smk
@@ -158,32 +158,25 @@ rule qc_reg_dwi_t1:
             **subj_wildcards
         ),
     output:
-        png=report(
-            bids(
-                root=root,
-                datatype="qc",
-                suffix="reg.png",
-                **subj_wildcards,
-                from_="dwiref",
-                to="T1w"
-            ),
-            caption="../report/reg_dwi_t1.rst",
-            category="B0 T1w registration",
-        ),
-        html=bids(
+        pics=directory(bids(
             root=root,
             datatype="qc",
-            suffix="reg.html",
+            suffix="reg",
             from_="dwiref",
             to="T1w",
-            **subj_wildcards
-        ),
+            **subj_wildcards,
+        ))
     group:
         "subj"
-    container:
-        config["singularity"]["python"]
-    script:
-        "../scripts/vis_regqc.py"
+    envmodules:
+        "mrtrix/3.0.1"
+    shell:
+        "mkdir -p {output.pics} && "
+        "xvfb-run -a bash -c 'mrview {input.flo} -overlay.load {input.ref} "
+        "-overlay.opacity 0.6 -overlay.threshold_min 0 -noannotations "
+        "-capture.folder {output.pics} "
+        "$(../scripts/mrview_capture {input.img}) -exit'"
+
 
 
 rule convert_xfm_ras2itk:

--- a/snakedwi/workflow/scripts/mrview_capture.sh
+++ b/snakedwi/workflow/scripts/mrview_capture.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -euo pipefail
+export IFS=$'\n'$'\t'' '
+
+print_help () {
+    cat <<EOF
+USAGE: mrview_capture img [slice]
+
+Outputs arguments that can be passed to mrview to capture a series of images
+across the axial, coronal, and sagital slices
+
+Args
+    img     the image to be captured. Used to calculate slice dimensions
+    slice   Optional argument specifying the range of captures to be made.
+            Follows pythonic START:STOP:STEP syntax. Defaults to ::10
+EOF
+}
+
+params=()
+while [[ -n "${1:-}" && ! "$1" == "--" ]]; do
+    case "${1:-help}" in
+        --help | -h)
+            print_help
+            exit 0
+            ;;
+        -* | --*)
+            echo "Error: Unsupported flag $1" >&2
+            exit 1
+            ;;
+        * )
+            params["${#params[@]}"]="$1"
+            ;;
+    esac
+    shift
+done
+
+if [[ "${#params[@]}" -gt 2 ]]; then
+    echo "Error: unrecognized args '${params[@]:2}'" >&2
+    exit 1
+fi
+
+if [[ "${#params[@]}" -eq 0 ]]; then
+    echo "Error: must provide path to image" >&2
+    exit 1
+fi
+
+
+# parse and validate image
+img="${params[0]}"
+if [[ ! -e $img ]]; then
+    echo "Error: Image does not exist: '$img'" >&2
+    exit 1
+fi
+
+
+# parse and validate slice
+eval $( echo "${params[1]:-"::"}" | awk -F':' '
+    {print "start="$1" stop="$2" step="$3" err="$4}
+')
+start="${start:-0}"
+step="${step:-10}"
+
+if [[ -n $err ]]; then
+    echo 'Error: slice must not have more than 3 numbers (START:STOP:SLICE)' >&2
+    exit 1
+fi
+
+is_number () {
+    [[ "$1" =~ ^-?[0-9]+$ ]]
+}
+
+for ix in "$start" "$stop" "$step"; do
+    is_number "$ix" || (echo "Error: '$ix' in slice '${params[1]}' is not a number" && exit 1)
+done
+
+if [[ "$start" -gt "$stop" ]]; then
+    echo "Error: Start value must not be greater than stop: '$start > $stop'" >&2
+    exit 1
+fi
+
+
+planes=(sagittal coronal axial)
+
+shape=($(mrinfo -size $img))
+
+i_mid=$(( shape[0] / 2 ))
+j_mid=$(( shape[1] / 2 ))
+k_mid=$(( shape[2] / 2 ))
+
+for plane_i in 0 1 2; do
+    printf -- '-plane %s -capture.prefix %s ' "$plane_i" "${planes[$plane_i]}"
+    stop_="${stop:-$(( shape[$plane_i] + step ))}"
+    i="$start"
+    while [[ "$i" -lt "$stop_" ]]; do
+        coord=($i_mid $j_mid $k_mid)
+        coord[$plane_i]="$i"
+        coord_str=$(echo ${coord[@]} | paste -s -d',')
+        printf -- '-voxel %s -capture.grab ' "$coord_str"
+        i=$(( i + step ))
+    done
+done


### PR DESCRIPTION
Here's the mrview-based qc. Both rules take an output directory and output a whole slew of snapshots taken from across the file. I've found it effective enough to just scroll through the snaps in a photo viewer, but maybe there's fancier formats you could get.

A helper script is included to calculate the coordinates for the snaps based on the image shape and output the appropriate commands for `mrview`. It's in bash: not ideal, but auto-calculating the shape of the image and using that to create a command turned out to be very messy affair with no ideal solution. It was either at least 2 (complicated) rules for each QC, or this bash script as far as I could tell. At least with the bash script it's fairly easy to copy/paste the rule.

The command is wrapped with `xvfb-run` for cluster support, but this may not actually be appropriate for all environments. Would have to test to know for sure.

One caveat is it actually takes a long to generate the snapshots (a couple minutes per file at least), so that needs to be factored into workflow time. If we choose to use this, perhaps QC should be opt-in? (Of course, the larger the step size, the faster the generation)