### PR TITLE
SynthSR+SyN for fieldmap-less distortion correction

### DIFF
--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -88,10 +88,10 @@ parse_args:
     default: False
 
   --use_bedpost: 
-    help: 'Enable bedpost  (default: %(default)s)'
+    help: 'Enable bedpost  (disabled by default)'
     action: 'store_false'
     dest: 'no_bedpost'
-    default: False
+    default: True
 
     #  --no_bedpost:
     #    help: 'Disable bedpost  (default: %(default)s)'

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -18,6 +18,7 @@ use_eddy_s2v: False
 eddy_no_quad: False
 no_bedpost: False
 use_syn_sdc: False
+use_synthsr_sdc: True 
 
 targets_by_analysis_level:
   participant:

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -13,12 +13,6 @@ derivatives: False
 analysis_levels: &analysis_levels
  - participant
 
-no_topup: False
-use_eddy_s2v: False
-eddy_no_quad: False
-no_bedpost: False
-use_syn_sdc: False
-use_synthsr_sdc: True 
 
 targets_by_analysis_level:
   participant:
@@ -93,10 +87,16 @@ parse_args:
     action: 'store_true'
     default: False
 
-  --no_bedpost:
-    help: 'Disable bedpost  (default: %(default)s)'
-    action: 'store_true'
+  --use_bedpost: 
+    help: 'Enable bedpost  (default: %(default)s)'
+    action: 'store_false'
+    dest: 'no_bedpost'
     default: False
+
+    #  --no_bedpost:
+    #    help: 'Disable bedpost  (default: %(default)s)'
+    #    action: 'store_true'
+    #    default: True
 
    
   --use_eddy_s2v:
@@ -295,6 +295,7 @@ eddy:
 default_effective_echo_spacing: 0.0001 #if not defined in JSON files
 
 #for test data
+root: 'results'
 participant_label: 
 exclude_participant_label:
 masking_method: b0_synthstrip
@@ -306,4 +307,7 @@ use_eddy_gpu: False
 use_bedpost_gpu: False
 rigid_dwi_t1_init: 'identity'
 rigid_dwi_t1_iters: '50x50'
-root: 'results'
+eddy_no_quad: False
+no_topup: False
+use_syn_sdc: False
+use_synthsr_sdc: True 

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -173,6 +173,9 @@ singularity:
   python: 'docker://khanlab/pythondeps-snakedwi:v0.2.0'  
   synthstrip: 'docker://freesurfer/synthstrip:1.3'
   sdcflows: 'docker://nipreps/fmriprep:22.1.1' #can't currently just use sdcflows docker as it is missing freesurfer's mri_robust_template
+  synthsr: 'docker://akhanf/synthsr:main'
+  synthmorph: 'docker://freesurfer/synthmorph:1'
+
 
 
 

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -157,6 +157,16 @@ parse_args:
     action: 'store_true'
     default: False
 
+    #  --synthsr_sdc:
+    #help: "Enable SynthSR+SyN fieldmap-less distortion-correction. This uses SynthSR to transform T1w and b0 images to the same 1mm T1w contrast prior to non-linear registration to obtain a field-map. (default: %(default)s)"
+    #action: 'store_true'
+    #default: True
+
+  --no_synthsr_sdc:
+    help: "Disable SynthSR+SyN fieldmap-less distortion-correction (enabled by default)"
+    action: 'store_false'
+    dest: 'use_synthsr_sdc'
+    default: True
 
 
 #---- to update below this

--- a/snakedwi/workflow/rules/eddy.smk
+++ b/snakedwi/workflow/rules/eddy.smk
@@ -101,6 +101,17 @@ def get_eddy_topup_fmap_input(wildcards):
                 **subj_wildcards,
             ).format(**wildcards),
         }
+    elif method == "synthsr":
+        return {
+            "fmap": bids(
+                root=work,
+                datatype="dwi",
+                suffix="fmap.nii.gz",
+                desc="b0",
+                method="synthSRsdc",
+                **subj_wildcards,
+            ).format(**wildcards)
+        }
     elif method == "syn":
         return {
             "fmap": bids(
@@ -130,6 +141,17 @@ def get_eddy_topup_fmap_opt(wildcards, input):
             root=work, suffix="topup", datatype="dwi", **subj_wildcards
         ).format(**wildcards)
         return f"--topup={topup_prefix}"
+    elif method == "synthsr":
+        fmap_prefix = bids(
+            root=work,
+            datatype="dwi",
+            suffix="fmap",
+            desc="b0",
+            method="synthSRsdc",
+            **subj_wildcards,
+        ).format(**wildcards)
+        return f"--field={fmap_prefix}"
+
     elif method == "syn":
         fmap_prefix = bids(
             root=work,

--- a/snakedwi/workflow/rules/masking_b0_synthstrip.smk
+++ b/snakedwi/workflow/rules/masking_b0_synthstrip.smk
@@ -22,6 +22,8 @@ rule synthstrip_b0:
     container:
         config["singularity"]["synthstrip"]
     threads: 8
+    shadow:
+        "minimal"
     group:
         "subj"
     shell:

--- a/snakedwi/workflow/rules/reg_dwi_to_t1.smk
+++ b/snakedwi/workflow/rules/reg_dwi_to_t1.smk
@@ -30,6 +30,8 @@ rule synthstrip_t1:
     container:
         config["singularity"]["synthstrip"]
     threads: 8
+    shadow:
+        "minimal"
     shell:
         "python3 /freesurfer/mri_synthstrip -i {input.t1} -m {output.mask}"
 

--- a/snakedwi/workflow/rules/reg_t1_to_template.smk
+++ b/snakedwi/workflow/rules/reg_t1_to_template.smk
@@ -54,8 +54,8 @@ rule convert_template_xfm_ras2itk:
             datatype="transforms",
             **subj_wildcards,
             suffix="xfm.txt",
-            from_="subject",
-            to="{template}",
+            from_="{from}",
+            to="{to}",
             desc="{desc}",
             type_="ras"
         ),
@@ -65,8 +65,8 @@ rule convert_template_xfm_ras2itk:
             datatype="transforms",
             **subj_wildcards,
             suffix="xfm.txt",
-            from_="subject",
-            to="{template}",
+            from_="{from}",
+            to="{to}",
             desc="{desc}",
             type_="itk"
         ),

--- a/snakedwi/workflow/rules/sdc.smk
+++ b/snakedwi/workflow/rules/sdc.smk
@@ -360,6 +360,8 @@ rule run_synthSR:
         "subj"
     container:
         config["singularity"]["synthsr"]
+    shadow:
+        "minimal"
     shell:
         "python /SynthSR/scripts/predict_command_line.py  --cpu --threads {threads} {input} {output}"
 

--- a/snakedwi/workflow/scripts/check_subj_dwi_metadata.py
+++ b/snakedwi/workflow/scripts/check_subj_dwi_metadata.py
@@ -89,3 +89,6 @@ if eddy_s2v:
 else:
     print("Disabling eddy s2v in the workflow")
     shell("touch {snakemake.output}/eddys2v-no")
+
+print("Writing phase encoding axis")
+shell("touch {snakemake.output}/PEaxis-{phase_encoding_axes[0]}")

--- a/snakedwi/workflow/scripts/check_subj_dwi_metadata.py
+++ b/snakedwi/workflow/scripts/check_subj_dwi_metadata.py
@@ -65,6 +65,13 @@ if len(set(phase_encoding_directions)) < 2:
             f"Opposing phase encoding directions not available, {phase_encoding_directions}, using syn for sdc"
         )
         shell("touch {snakemake.output}/sdc-syn")
+    elif snakemake.config["use_synthsr_sdc"]:
+
+        print(
+            f"Opposing phase encoding directions not available, {phase_encoding_directions}, using synthSR+Syn for sdc"
+        )
+        shell("touch {snakemake.output}/sdc-synthsr")
+
     else:
         print(
             f"Opposing phase encoding directions not available, {phase_encoding_directions}, skipping sdc"

--- a/snakedwi/workflow/scripts/displacement_field_to_fmap.py
+++ b/snakedwi/workflow/scripts/displacement_field_to_fmap.py
@@ -1,0 +1,32 @@
+import nibabel as nib
+import json
+from sdcflows.transform import disp_to_fmap
+import numpy as np
+
+
+# adapted from sdcflows DisplacementsField2Fieldmap Interface
+with open(snakemake.input.dwi_json, "r") as f:
+    json_dwi = json.load(f)
+
+# get phenc dir, and calculate required readout time
+pe_dir = json_dwi["PhaseEncodingDirection"]
+shape_dwi = nib.load(snakemake.input.dwi_nii).get_fdata().shape
+n_pe = shape_dwi["ijk".index(pe_dir[0])]
+ro_time = json_dwi["EffectiveEchoSpacing"] * (n_pe - 1)
+
+# pass this on to the sdcflows function
+nib_fmap = disp_to_fmap(nib.load(snakemake.input.disp_field), ro_time, pe_dir)
+
+# demean the fieldmap
+if snakemake.params.demean:
+    data = np.asanyarray(nib_fmap.dataobj)
+    data -= np.median(data)
+
+    fmapnii = nib_fmap.__class__(
+        data.astype("float32"),
+        nib_fmap.affine,
+        nib_fmap.header,
+    )
+
+# save it
+nib_fmap.to_filename(snakemake.output.fmap)


### PR DESCRIPTION
This implements a novel SynthSR+SyN method for fieldmap-less distortion correction. It is similar to the SyN method used in SDCFlows, except, the b0 and T1w images are transformed to T1w-like 1mm images before performing registration, which makes the registration much more robust. 

This is now set-up as a the default method to use when topup cannot be used (ie no opposite phase encoding directions). 

Also a couple other miscellaneous changes here: 
 - add shadow to synthstrip/synthsr rules
 - disable bedpost by default