### PR TITLE
automated selection of dwi scans, intersection of t1 and dwi zip lists, metadata summary files

### DIFF
--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -168,6 +168,16 @@ parse_args:
     dest: 'use_synthsr_sdc'
     default: True
 
+  --default_phase_encoding_direction:
+    help: "Sets the PhaseEncodingDirection to use for dwi acquisitions where it is not specified in the JSON file. By default, none will be assumed, and the workflow will fail for subjects where this JSON tag is missing (default: %(default)s)"
+    default: ''
+    choices:
+      - 'i'
+      - 'i-'
+      - 'j'
+      - 'j-'
+      - 'k'
+      - 'k-'
 
 #---- to update below this
 
@@ -311,3 +321,4 @@ eddy_no_quad: False
 no_topup: False
 use_syn_sdc: False
 use_synthsr_sdc: True 
+default_phase_encoding_direction: ''

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -1,5 +1,5 @@
-bids_dir: 'test_data/bids_multishell_downsampled_notopup'
-output_dir: 'test_output/snakedwi_multishell_downsampled_notopup'
+bids_dir: 'test_data/bids_multishell_downsampled'
+output_dir: 'test_output/snakedwi_multishell_downsampled'
 
 #enable printing debug statements during parsing -- disable if generating dag visualization
 debug: False

--- a/snakedwi/workflow/Snakefile
+++ b/snakedwi/workflow/Snakefile
@@ -35,7 +35,7 @@ rule all:
                 **subj_wildcards
             ),
             zip,
-            **input_zip_lists["dwi"]
+            **subj_zip_list
         ),
         reg_qc=expand(
             bids(
@@ -47,7 +47,7 @@ rule all:
                 **subj_wildcards
             ),
             zip,
-            **input_zip_lists["dwi"]
+            **subj_zip_list
         ),
         dtifit=expand(
             bids(
@@ -60,5 +60,5 @@ rule all:
                 **subj_wildcards
             ),
             zip,
-            **input_zip_lists["dwi"]
+            **subj_zip_list
         ),

--- a/snakedwi/workflow/Snakefile
+++ b/snakedwi/workflow/Snakefile
@@ -66,9 +66,5 @@ rule all:
 
 rule all_metacheck:
     input:
-        workflowopts=expand(
-            bids(root=root, datatype="dwi", suffix="workflowopts", **subj_wildcards),
-            zip,
-            **subj_zip_list
-        ),
         missing_subj_tsv=bids(root=root, suffix="missing.tsv"),
+        metadata_subj_tsv=bids(root=root, suffix="metadata.tsv"),

--- a/snakedwi/workflow/Snakefile
+++ b/snakedwi/workflow/Snakefile
@@ -62,3 +62,13 @@ rule all:
             zip,
             **subj_zip_list
         ),
+
+
+rule all_metacheck:
+    input:
+        workflowopts=expand(
+            bids(root=root, datatype="dwi", suffix="workflowopts", **subj_wildcards),
+            zip,
+            **subj_zip_list
+        ),
+        missing_subj_tsv=bids(root=root, suffix="missing.tsv"),

--- a/snakedwi/workflow/Snakefile
+++ b/snakedwi/workflow/Snakefile
@@ -3,6 +3,7 @@ configfile: "config/snakebids.yml"
 
 include: "rules/setup.smk"
 include: "rules/common.smk"
+include: "rules/workflowopts.smk"
 include: "rules/prepdwi.smk"
 include: "rules/sdc.smk"
 include: "rules/eddy.smk"

--- a/snakedwi/workflow/rules/common.smk
+++ b/snakedwi/workflow/rules/common.smk
@@ -6,7 +6,7 @@ def get_eddy_quad_all():
             "eddy_qc": expand(
                 bids(root=root, datatype="qc", suffix="eddyqc", **subj_wildcards),
                 zip,
-                **input_zip_lists["dwi"]
+                **subj_zip_list
             )
         }
 
@@ -27,6 +27,6 @@ def get_bedpost_all():
                     **subj_wildcards
                 ),
                 zip,
-                **input_zip_lists["dwi"]
+                **subj_zip_list
             )
         }

--- a/snakedwi/workflow/rules/eddy.smk
+++ b/snakedwi/workflow/rules/eddy.smk
@@ -1,15 +1,18 @@
 rule get_eddy_index_txt:
     input:
-        dwi_niis=lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="dwi.nii.gz",
-                desc="degibbs",
-                datatype="dwi",
-                **input_wildcards["dwi"]
+        dwi_niis=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.nii.gz",
+                    desc="degibbs",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
     output:
         eddy_index_txt=bids(
@@ -32,16 +35,19 @@ if not config["slspec_txt"]:
 
     rule get_slspec_txt:
         input:
-            dwi_jsons=lambda wildcards: expand(
-                bids(
-                    root=work,
-                    suffix="dwi.json",
-                    desc="degibbs",
-                    datatype="dwi",
-                    **input_wildcards["dwi"]
+            dwi_jsons=lambda wildcards: get_dwi_indices(
+                expand(
+                    bids(
+                        root=work,
+                        suffix="dwi.json",
+                        desc="degibbs",
+                        datatype="dwi",
+                        **input_wildcards["dwi"]
+                    ),
+                    zip,
+                    **filter_list(input_zip_lists["dwi"], wildcards)
                 ),
-                zip,
-                **filter_list(input_zip_lists["dwi"], wildcards)
+                wildcards,
             ),
         output:
             eddy_slspec_txt=bids(

--- a/snakedwi/workflow/rules/eddy.smk
+++ b/snakedwi/workflow/rules/eddy.smk
@@ -85,12 +85,9 @@ else:
 
 
 def get_eddy_topup_fmap_input(wildcards):
-    # this gets the number of DWI scans for this subject(session)
-    filtered = filter_list(input_zip_lists["dwi"], wildcards)
-    num_scans = len(filtered["subject"])
 
-    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
-    ([method],) = glob_wildcards(os.path.join(checkpoint_output, "sdc-{method}"))
+    method = get_sdc_method(wildcards)
+    num_scans = get_dwi_num_scans(wildcards)
 
     if num_scans > 1 and method == "topup":
         return {
@@ -135,12 +132,8 @@ def get_eddy_topup_fmap_input(wildcards):
 
 def get_eddy_topup_fmap_opt(wildcards, input):
 
-    # this gets the number of DWI scans for this subject(session)
-    filtered = filter_list(input_zip_lists["dwi"], wildcards)
-    num_scans = len(filtered["subject"])
-
-    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
-    ([method],) = glob_wildcards(os.path.join(checkpoint_output, "sdc-{method}"))
+    method = get_sdc_method(wildcards)
+    num_scans = get_dwi_num_scans(wildcards)
 
     if num_scans > 1 and method == "topup":
         topup_prefix = bids(
@@ -174,10 +167,7 @@ def get_eddy_topup_fmap_opt(wildcards, input):
 
 def get_eddy_s2v_opts(wildcards, input):
 
-    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
-    ([s2v_is_enabled],) = glob_wildcards(
-        os.path.join(checkpoint_output, "eddys2v-{isenabled}")
-    )
+    s2v_is_enabled = get_enable_s2v(wildcards)
 
     options = []
     if s2v_is_enabled == "yes":
@@ -198,10 +188,7 @@ def get_eddy_s2v_opts(wildcards, input):
 
 def get_eddy_slspec_input(wildcards):
 
-    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
-    ([s2v_is_enabled],) = glob_wildcards(
-        os.path.join(checkpoint_output, "eddys2v-{isenabled}")
-    )
+    s2v_is_enabled = get_enable_s2v(wildcards)
 
     if s2v_is_enabled == "yes":
         return {
@@ -220,10 +207,7 @@ def get_eddy_slspec_input(wildcards):
 
 def get_eddy_slspec_opt(wildcards, input):
 
-    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
-    ([s2v_is_enabled],) = glob_wildcards(
-        os.path.join(checkpoint_output, "eddys2v-{isenabled}")
-    )
+    s2v_is_enabled = get_enable_s2v(wildcards)
 
     if s2v_is_enabled == "yes":
         return f"--slspec={input.eddy_slspec_txt}"

--- a/snakedwi/workflow/rules/prepdwi.smk
+++ b/snakedwi/workflow/rules/prepdwi.smk
@@ -20,6 +20,19 @@ checkpoint check_subj_dwi_metadata:
         "../scripts/check_subj_dwi_metadata.py"
 
 
+rule create_missing_subj_tsv:
+    """creates a tsv file containing subjects that are 
+    skipped because they either don't have T1w or don't have dwi data"""
+    params:
+        missing_subject_zip_list=missing_subj_zip_list,
+    output:
+        tsv=bids(root=root, suffix="missing.tsv"),
+    container:
+        config["singularity"]["python"]
+    script:
+        "../scripts/create_missing_subj_tsv.py"
+
+
 rule import_dwi:
     input:
         dwi=re.sub(".nii.gz", ".{ext}", input_path["dwi"]),

--- a/snakedwi/workflow/rules/prepdwi.smk
+++ b/snakedwi/workflow/rules/prepdwi.smk
@@ -243,16 +243,19 @@ rule get_phase_encode_txt:
 
 rule concat_phase_encode_txt:
     input:
-        phenc_txts=lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="phenc.txt",
-                datatype="dwi",
-                desc="degibbs",
-                **input_wildcards["dwi"]
+        phenc_txts=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="phenc.txt",
+                    datatype="dwi",
+                    desc="degibbs",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
     output:
         phenc_concat=bids(
@@ -280,18 +283,30 @@ def get_concat_or_cp_cmd(wildcards, input, output):
     return cmd
 
 
+def get_dwi_indices(all_dwi, wildcards):
+    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
+    ([indices_str],) = glob_wildcards(
+        os.path.join(checkpoint_output, "indices-{indices}")
+    )
+    indices = indices_str.split(",")
+    return [all_dwi[int(i)] for i in indices]
+
+
 rule concat_bzeros:
     input:
-        bzero_niis=lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="b0.nii.gz",
-                datatype="dwi",
-                desc="degibbs",
-                **input_wildcards["dwi"]
+        bzero_niis=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="b0.nii.gz",
+                    datatype="dwi",
+                    desc="degibbs",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
     params:
         cmd=get_concat_or_cp_cmd,
@@ -315,16 +330,19 @@ rule concat_bzeros:
 
 rule concat_degibbs_dwi:
     input:
-        dwi_niis=lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="dwi.nii.gz",
-                desc="degibbs",
-                datatype="dwi",
-                **input_wildcards["dwi"]
+        dwi_niis=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.nii.gz",
+                    desc="degibbs",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
     params:
         cmd=get_concat_or_cp_cmd,
@@ -348,16 +366,19 @@ rule concat_degibbs_dwi:
 
 rule concat_runs_bvec:
     input:
-        lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="dwi.bvec",
-                desc="{{desc}}",
-                datatype="dwi",
-                **input_wildcards["dwi"]
+        lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.bvec",
+                    desc="{{desc}}",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
     output:
         bids(
@@ -377,16 +398,19 @@ rule concat_runs_bvec:
 
 rule concat_runs_bval:
     input:
-        lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="dwi.bval",
-                desc="{{desc}}",
-                datatype="dwi",
-                **input_wildcards["dwi"]
+        lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.bval",
+                    desc="{{desc}}",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
     output:
         bids(
@@ -407,16 +431,19 @@ rule concat_runs_bval:
 # combines json files from multiple scans -- for now as a hack just copying first json over..
 rule concat_runs_json:
     input:
-        lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="dwi.json",
-                desc="{{desc}}",
-                datatype="dwi",
-                **input_wildcards["dwi"]
+        lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.json",
+                    desc="{{desc}}",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
     output:
         bids(

--- a/snakedwi/workflow/rules/prepdwi.smk
+++ b/snakedwi/workflow/rules/prepdwi.smk
@@ -10,10 +10,17 @@ checkpoint check_subj_dwi_metadata:
             zip,
             **filter_list(input_zip_lists["dwi"], wildcards)
         ),
+    params:
+        index_col_value=bids(
+            **subj_wildcards, include_subject_dir=False, include_session_dir=False
+        ),
+        index_col_name="subj",
+
     output:
         workflowopts=directory(
             bids(root=root, datatype="dwi", suffix="workflowopts", **subj_wildcards)
         ),
+        metadata=bids(root=root, datatype="dwi", suffix="metadata.tsv", **subj_wildcards)
     group:
         "subj"
     script:

--- a/snakedwi/workflow/rules/prepdwi.smk
+++ b/snakedwi/workflow/rules/prepdwi.smk
@@ -15,16 +15,32 @@ checkpoint check_subj_dwi_metadata:
             **subj_wildcards, include_subject_dir=False, include_session_dir=False
         ),
         index_col_name="subj",
-
     output:
         workflowopts=directory(
             bids(root=root, datatype="dwi", suffix="workflowopts", **subj_wildcards)
         ),
-        metadata=bids(root=root, datatype="dwi", suffix="metadata.tsv", **subj_wildcards)
+        metadata=bids(
+            root=root, datatype="dwi", suffix="metadata.tsv", **subj_wildcards
+        ),
     group:
         "subj"
     script:
         "../scripts/check_subj_dwi_metadata.py"
+
+
+rule concat_subj_metadata:
+    input:
+        tsvs=expand(
+            bids(root=root, datatype="dwi", suffix="metadata.tsv", **subj_wildcards),
+            zip,
+            **subj_zip_list
+        ),
+    output:
+        tsv=bids(root=root, suffix="metadata.tsv"),
+    container:
+        config["singularity"]["python"]
+    script:
+        "../scripts/concat_tsv.py"
 
 
 rule create_missing_subj_tsv:

--- a/snakedwi/workflow/rules/sdc.smk
+++ b/snakedwi/workflow/rules/sdc.smk
@@ -55,16 +55,19 @@ rule run_topup:
 # this is for equal positive and negative blipped data - method=lsr --unused currently (jac method can be applied more generally)
 rule apply_topup_lsr:
     input:
-        dwi_niis=lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="dwi.nii.gz",
-                desc="degibbs",
-                datatype="dwi",
-                **input_wildcards["dwi"]
+        dwi_niis=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.nii.gz",
+                    desc="degibbs",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
         phenc_concat=bids(
             root=work,
@@ -236,17 +239,20 @@ rule cp_sidecars_topup_jac:
 
 rule concat_dwi_topup_jac:
     input:
-        dwi_niis=lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="dwi.nii.gz",
-                desc="topup",
-                method="jac",
-                datatype="dwi",
-                **input_wildcards["dwi"]
+        dwi_niis=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.nii.gz",
+                    desc="topup",
+                    method="jac",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         ),
     output:
         dwi_concat=bids(
@@ -281,12 +287,18 @@ rule syn_sdc:
             desc="preproc",
             suffix="T1w.nii.gz"
         ),
-        json_file=lambda wildcards: expand(
-            bids(
-                root=work, suffix="dwi.json", datatype="dwi", **input_wildcards["dwi"]
+        json_file=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.json",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         )[0],
         mask_anat=bids(
             root=root,
@@ -525,22 +537,31 @@ rule displacement_field_to_fmap:
             datatype="transforms",
             **subj_wildcards
         ),
-        dwi_nii=lambda wildcards: expand(
-            bids(
-                root=work,
-                suffix="dwi.nii.gz",
-                datatype="dwi",
-                **input_wildcards["dwi"]
+        dwi_nii=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.nii.gz",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         )[0],
-        dwi_json=lambda wildcards: expand(
-            bids(
-                root=work, suffix="dwi.json", datatype="dwi", **input_wildcards["dwi"]
+        dwi_json=lambda wildcards: get_dwi_indices(
+            expand(
+                bids(
+                    root=work,
+                    suffix="dwi.json",
+                    datatype="dwi",
+                    **input_wildcards["dwi"]
+                ),
+                zip,
+                **filter_list(input_zip_lists["dwi"], wildcards)
             ),
-            zip,
-            **filter_list(input_zip_lists["dwi"], wildcards)
+            wildcards,
         )[0],
     params:
         demean=True,

--- a/snakedwi/workflow/rules/setup.smk
+++ b/snakedwi/workflow/rules/setup.smk
@@ -76,7 +76,11 @@ if "session" in zipl:
         "session": seszip,
     }  # create the new subj_zip_list
 
-    (msubzip, mseszip) = zip(*list(subj_set_difference))  # zip it up again
+    if len(subj_set_difference) > 0:
+        (msubzip, mseszip) = zip(*list(subj_set_difference))  # zip it up again
+    else:
+        msubzip = []
+        mseszip = []
     missing_subj_zip_list = {
         "subject": msubzip,
         "session": mseszip,

--- a/snakedwi/workflow/rules/setup.smk
+++ b/snakedwi/workflow/rules/setup.smk
@@ -80,7 +80,6 @@ else:
     subj_zip_list = {"subject": list(subj_set_intersection)}
 
 # ------------------------------------------------------------------------------
-
 # if len(subj_set_difference) > 0:
 #    print(f'Skipping following (subjects/sessions) since they are missing one of the required bids inputs: {subj_set_difference}')
 #    print(subj_zip_list)

--- a/snakedwi/workflow/rules/setup.smk
+++ b/snakedwi/workflow/rules/setup.smk
@@ -38,3 +38,49 @@ work = os.path.join(config["root"], "work")
 #            root=Path('work'),
 #            requirements=['workflow/pipenvs/snakedwi.txt'],
 # )
+
+
+# create a subj_zip_list bids_input var to loop over subjects/sessions where
+# *all* the pybids inputs are present (e.g. T1w and dwi both present)
+#
+# does this by performing a set intersection of the (subject+session only) zip lists for different modalities
+
+subj_set_intersection = None
+subj_set_union = None  # union not really used except for finding set union - intersection (skipped subjects)
+subj_zip_list = None
+
+for bidsinput in config["pybids_inputs"].keys():
+    zipl = inputs.input_zip_lists[bidsinput]
+    if "session" in zipl:
+        # has session, so we have to zip, then use set to remove duplicates
+        subj_set = set(zip(zipl["subject"], zipl["session"]))
+    else:
+        # does not have session, so we can remove duplicates easily by using set
+        subj_set = set(zipl["subject"])
+
+    subj_set_intersection = (
+        subj_set
+        if subj_set_intersection == None
+        else subj_set.intersection(subj_set_intersection)
+    )
+    subj_set_union = (
+        subj_set if subj_set_union == None else subj_set.union(subj_set_union)
+    )
+
+
+subj_set_difference = subj_set_union - subj_set_intersection
+if "session" in zipl:
+    (subzip, seszip) = zip(*list(subj_set_intersection))  # zip it up again
+    subj_zip_list = {
+        "subject": subzip,
+        "session": seszip,
+    }  # create the new subj_zip_list
+
+else:
+    subj_zip_list = {"subject": list(subj_set_intersection)}
+
+# ------------------------------------------------------------------------------
+
+# if len(subj_set_difference) > 0:
+#    print(f'Skipping following (subjects/sessions) since they are missing one of the required bids inputs: {subj_set_difference}')
+#    print(subj_zip_list)

--- a/snakedwi/workflow/rules/setup.smk
+++ b/snakedwi/workflow/rules/setup.smk
@@ -77,7 +77,7 @@ if "session" in zipl:
     }  # create the new subj_zip_list
 
     (msubzip, mseszip) = zip(*list(subj_set_difference))  # zip it up again
-    missing_zip_list = {
+    missing_subj_zip_list = {
         "subject": msubzip,
         "session": mseszip,
     }

--- a/snakedwi/workflow/rules/setup.smk
+++ b/snakedwi/workflow/rules/setup.smk
@@ -76,9 +76,14 @@ if "session" in zipl:
         "session": seszip,
     }  # create the new subj_zip_list
 
+    (msubzip, mseszip) = zip(*list(subj_set_difference))  # zip it up again
+    missing_zip_list = {
+        "subject": msubzip,
+        "session": mseszip,
+    }
 else:
     subj_zip_list = {"subject": list(subj_set_intersection)}
-
+    missing_subj_zip_list = {"subject": list(subj_set_difference)}
 # ------------------------------------------------------------------------------
 # if len(subj_set_difference) > 0:
 #    print(f'Skipping following (subjects/sessions) since they are missing one of the required bids inputs: {subj_set_difference}')

--- a/snakedwi/workflow/rules/workflowopts.smk
+++ b/snakedwi/workflow/rules/workflowopts.smk
@@ -1,0 +1,126 @@
+checkpoint check_subj_dwi_metadata:
+    input:
+        dwi_jsons=lambda wildcards: expand(
+            re.sub(".nii.gz", ".json", input_path["dwi"]),
+            zip,
+            **filter_list(input_zip_lists["dwi"], wildcards)
+        ),
+    params:
+        index_col_value=bids(
+            **subj_wildcards, include_subject_dir=False, include_session_dir=False
+        ),
+        index_col_name="subj",
+    output:
+        workflowopts=directory(
+            bids(root=root, datatype="dwi", suffix="workflowopts", **subj_wildcards)
+        ),
+        metadata=bids(
+            root=root, datatype="dwi", suffix="metadata.tsv", **subj_wildcards
+        ),
+    group:
+        "subj"
+    script:
+        "../scripts/check_subj_dwi_metadata.py"
+
+
+rule concat_subj_metadata:
+    input:
+        tsvs=expand(
+            bids(root=root, datatype="dwi", suffix="metadata.tsv", **subj_wildcards),
+            zip,
+            **subj_zip_list
+        ),
+    output:
+        tsv=bids(root=root, suffix="metadata.tsv"),
+    container:
+        config["singularity"]["python"]
+    script:
+        "../scripts/concat_tsv.py"
+
+
+rule create_missing_subj_tsv:
+    """creates a tsv file containing subjects that are 
+    skipped because they either don't have T1w or don't have dwi data"""
+    params:
+        missing_subject_zip_list=missing_subj_zip_list,
+    output:
+        tsv=bids(root=root, suffix="missing.tsv"),
+    container:
+        config["singularity"]["python"]
+    script:
+        "../scripts/create_missing_subj_tsv.py"
+
+
+def get_dwi_indices(all_dwi, wildcards):
+    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
+    ([indices_str],) = glob_wildcards(
+        os.path.join(checkpoint_output, "indices-{indices}")
+    )
+    indices = indices_str.split(",")
+    return [all_dwi[int(i)] for i in indices]
+
+
+def get_dwi_indices_only(wildcards):
+    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
+    ([indices_str],) = glob_wildcards(
+        os.path.join(checkpoint_output, "indices-{indices}")
+    )
+    indices = indices_str.split(",")
+    return [int(i) for i in indices]
+
+
+def get_sdc_method(wildcards):
+    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
+    # this gets the sdc method for this subject(session)
+    ([method],) = glob_wildcards(os.path.join(checkpoint_output, "sdc-{method}"))
+    return method
+
+
+def get_dwi_num_scans(wildcards):
+    # this gets the number of DWI scans for this subject(session)
+    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
+    ([indices_str],) = glob_wildcards(
+        os.path.join(checkpoint_output, "indices-{indices}")
+    )
+    indices = indices_str.split(",")
+    return len(indices)
+
+
+def get_pe_axis(wildcards):
+
+    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
+    ([peaxis],) = glob_wildcards(os.path.join(checkpoint_output, "PEaxis-{axis}"))
+    return peaxis
+
+
+def get_enable_s2v(wildcards):
+    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
+    ([s2v_is_enabled],) = glob_wildcards(
+        os.path.join(checkpoint_output, "eddys2v-{isenabled}")
+    )
+    return s2v_is_enabled
+
+
+def get_index_of_dwi_scan(wildcards):
+    """given wildcards into a specific dwi acquisition, this returns the 0-based
+    index of that scan in the list of dwi scans in use for this acquisition"""
+    checkpoint_output = checkpoints.check_subj_dwi_metadata.get(**wildcards).output[0]
+    ([indices_str],) = glob_wildcards(
+        os.path.join(checkpoint_output, "indices-{indices}")
+    )
+    dwi_indices = [int(i) for i in indices_str.split(",")]
+
+    # first filter the ziplist to get the subject(+session)
+    subj_filter = {"subject": wildcards.subject}
+    if "session" in subj_wildcards.keys():
+        subj_filter["session"] = wildcards.session
+
+    zip_list_subj = filter_list(input_zip_lists["dwi"], subj_filter)
+
+    # filter the zip list using the indices
+    for zkey, zlist in zip_list_subj.items():
+        zip_list_subj[zkey] = [zlist[i] for i in dwi_indices]
+
+    # now filter the subj ziplist using all wildcards to get the index of the scan
+    indices = filter_list(zip_list_subj, wildcards, return_indices_only=True)
+    return indices[0]

--- a/snakedwi/workflow/scripts/check_subj_dwi_metadata.py
+++ b/snakedwi/workflow/scripts/check_subj_dwi_metadata.py
@@ -15,9 +15,7 @@ df = pd.DataFrame()
 row = dict()
 
 
-has_pedir = True
 has_slice_timing = True
-
 
 for json_file in snakemake.input:
 
@@ -45,10 +43,24 @@ for json_file in snakemake.input:
             sys.exit(1)
 
     if "PhaseEncodingDirection" not in json_dwi:
-        print(f"ERROR: PhaseEncodingDirection not found in {json_file}")
-        print("You must add the PhaseEncodingDirection field to your dwi JSON files")
-        sys.exit(1)
-        has_pedir = False
+
+        if not config["default_phase_encoding_direction"] == "":
+            print(f"WARNING: setting default PhaseEncodingDirection")
+            json_dwi["PhaseEncodingDirection"] = config[
+                "default_phase_encoding_direction"
+            ]
+        else:
+            if "PhaseEncodingAxis" in json_dwi:
+                print(
+                    f"WARNING: assuming PhaseEncodingDirection from PhaseEncodingAxis"
+                )
+                json_dwi["PhaseEncodingDirection"] = json_dwi["PhaseEncodingAxis"]
+            else:
+                print(f"ERROR: PhaseEncodingDirection not found in {json_file}")
+                print(
+                    "You must add the PhaseEncodingDirection field to your dwi JSON files, or use the --default_phase_encoding_direction CLI option"
+                )
+                sys.exit(1)
 
     phenc_dirs.append(json_dwi["PhaseEncodingDirection"])
 
@@ -59,6 +71,7 @@ for json_file in snakemake.input:
         phase_encoding_directions.append("+")
 
 # print(f"PhaseEncodingDirections: {phenc_dirs}")
+
 
 if len(set(phase_encoding_axes)) > 1:
     #    print(f"WARNING: Multiple phase encoding axes used {phase_encoding_axes}")

--- a/snakedwi/workflow/scripts/check_subj_dwi_metadata.py
+++ b/snakedwi/workflow/scripts/check_subj_dwi_metadata.py
@@ -28,7 +28,7 @@ for json_file in snakemake.input:
         if "SliceTiming" not in json_dwi:
             has_slice_timing = False
 
-            print(f"WARNING: disabling s2v for {snakemake.wildcards}")
+            # print(f"WARNING: disabling s2v for {snakemake.wildcards}")
 
             eddy_s2v = False
 
@@ -58,10 +58,10 @@ for json_file in snakemake.input:
     else:
         phase_encoding_directions.append("+")
 
-print(f"PhaseEncodingDirections: {phenc_dirs}")
+# print(f"PhaseEncodingDirections: {phenc_dirs}")
 
 if len(set(phase_encoding_axes)) > 1:
-    print(f"WARNING: Multiple phase encoding axes used {phase_encoding_axes}")
+    #    print(f"WARNING: Multiple phase encoding axes used {phase_encoding_axes}")
 
     # select indices to use
     # pick LR/RL *only* if it also has multiple directions
@@ -79,7 +79,6 @@ if len(set(phase_encoding_axes)) > 1:
         use_indices = ap_indices
 
 else:
-    print(f"Phase encoding axes: {phase_encoding_axes}")
     # use all indices
     use_indices = [i for i in range(len(snakemake.input))]
 
@@ -92,7 +91,7 @@ phase_encoding_directions = [phase_encoding_directions[i] for i in use_indices]
 # make the output folder
 shell("mkdir -p {snakemake.output.workflowopts}")
 
-print(use_indices)
+# print(use_indices)
 
 write_indices = ",".join([f"{ind}" for ind in use_indices])
 
@@ -100,38 +99,45 @@ write_indices = ",".join([f"{ind}" for ind in use_indices])
 shell("touch {snakemake.output.workflowopts}/indices-{write_indices}")
 
 if len(set(phase_encoding_directions)) < 2:
-    if snakemake.config["use_syn_sdc"]:
+    if phase_encoding_axes[0] == "i":
 
         print(
-            f"Opposing phase encoding directions not available, {phase_encoding_directions}, using syn for sdc"
+            "ERROR: Only one phase encoding direction with LR or RL - sdc will be inaccurate, so failing instead!"
         )
+        sys.exit(1)
+
+    if snakemake.config["use_syn_sdc"]:
+
+        # print(
+        #    f"Opposing phase encoding directions not available, {phase_encoding_directions}, using syn for sdc"
+        # )
         shell("touch {snakemake.output.workflowopts}/sdc-syn")
     elif snakemake.config["use_synthsr_sdc"]:
 
-        print(
-            f"Opposing phase encoding directions not available, {phase_encoding_directions}, using synthSR+Syn for sdc"
-        )
+        # print(
+        #    f"Opposing phase encoding directions not available, {phase_encoding_directions}, using synthSR+Syn for sdc"
+        # )
         shell("touch {snakemake.output.workflowopts}/sdc-synthsr")
 
     else:
-        print(
-            f"Opposing phase encoding directions not available, {phase_encoding_directions}, skipping sdc"
-        )
+        # print(
+        #    f"Opposing phase encoding directions not available, {phase_encoding_directions}, skipping sdc"
+        # )
         shell("touch {snakemake.output.workflowopts}/sdc-none")
 else:
-    print(
-        f"Opposing phase encoding directions are available, {phase_encoding_directions}, using topup for sdc"
-    )
+    # print(
+    #    f"Opposing phase encoding directions are available, {phase_encoding_directions}, using topup for sdc"
+    # )
     shell("touch {snakemake.output.workflowopts}/sdc-topup")
 
 if eddy_s2v:
-    print("Enabling eddy s2v in the workflow")
+    # print("Enabling eddy s2v in the workflow")
     shell("touch {snakemake.output.workflowopts}/eddys2v-yes")
 else:
-    print("Disabling eddy s2v in the workflow")
+    # print("Disabling eddy s2v in the workflow")
     shell("touch {snakemake.output.workflowopts}/eddys2v-no")
 
-print("Writing phase encoding axis")
+# print("Writing phase encoding axis")
 shell("touch {snakemake.output.workflowopts}/PEaxis-{phase_encoding_axes[0]}")
 
 # sets the index column as sub-{subject} or sub-{subject}_ses-{session}

--- a/snakedwi/workflow/scripts/concat_tsv.py
+++ b/snakedwi/workflow/scripts/concat_tsv.py
@@ -1,0 +1,5 @@
+import pandas as pd
+
+pd.concat([pd.read_csv(tsv, sep="\t") for tsv in snakemake.input.tsvs]).to_csv(
+    snakemake.output.tsv, index=False, sep="\t"
+)

--- a/snakedwi/workflow/scripts/create_missing_subj_tsv.py
+++ b/snakedwi/workflow/scripts/create_missing_subj_tsv.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+df = pd.DataFrame()
+
+missing_subj_zip_list = snakemake.params.missing_subject_zip_list
+
+df["participant_id"] = missing_subj_zip_list["subject"]
+
+if "session" in missing_subj_zip_list:
+    df["session"] = missing_subj_zip_list["session"]
+
+df.to_csv(snakemake.output.tsv, sep="\t", index=False)


### PR DESCRIPTION
- skip subjects that don't have both t1 and dwi
- added all_metacheck target rule
   - creates workflowopts for all subjects, and a tsv table of subjects(+sessions) that were
   missing dwi or T1w data
- check and select dwi indices to use in workflowopts
   - for the case when multiple different phase encode axes are used
   - e.g. if multiple phase encoding axes available, it picks the one,
and ignores the other dwi data..
   - fail out if only a single LR/RL scan (since cannot effectively perform SDC)
- refactor workflowopts
  - moved metadata check and related functions to workflowopts.smk
  - created functions for grabbing workflow opts
- added CLI for setting default pe dir, and will use peaxis as substitute if single scan and no default
