### PR TITLE
Alternate method for SDC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version
+            }}
     #----------------------------------------------
     # install dependencies if cache does not exist
     #----------------------------------------------
@@ -118,6 +119,5 @@ jobs:
     #----------------------------------------------
     # Run tests
     #----------------------------------------------
-      - name: Test dry-run 
+      - name: Test dry-run
         run: poetry run poe test_dryrun
-

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -132,6 +132,15 @@ parse_args:
       - 'sdcflow'
       - 'synthsr'
       - 'none'
+
+  --sdc_method_alternate:
+    help: 'Set alternate method to be used for single phase encoding SDC when 
+          "--sdc_method" is set to "optimal", otherwise this flag is ignored.
+          (default: %(default)s)'
+    default: 'synthsr'
+    choices:
+      - 'sdcflow'
+      - 'synthsr'
           
   # Eddy options
   --use_eddy_s2v:

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -85,16 +85,11 @@ parse_args:
   --skip_denoise:
     help: 'Skip the denoising step of the workflow. By default, denoising is 
           performed if input diffusion data was acquired with at least 30 
-          drections. (default: %(default)s)'
+          directions. (default: %(default)s)'
 
   --derivatives:
     action: 'store_true'
     default: False
-
-  --no_topup:
-    help: 'Disable topup  (default: %(default)s)'
-    action: 'store_true'
-    default: False 
 
   # B0 masking options
   --masking_method:

--- a/snakedwi/workflow/scripts/metadata/check_subj_dwi_metadata.py
+++ b/snakedwi/workflow/scripts/metadata/check_subj_dwi_metadata.py
@@ -109,7 +109,7 @@ def set_sdc_method(
         if len(set(pe_dirs)) >= 2:  # Opp PE
             shell(f"touch {workflowopts}/sdc-topup")
         else:  # Single PE
-            shell(f"touch {workflowopts}/sdc-synthsr")
+            shell(f"touch {workflowopts}/" f"sdc-{smk_config['sdc_method_alternate']}")
 
     else:
         shell(f"touch {workflowopts}/sdc-{smk_config['sdc_method']}")

--- a/snakedwi/workflow/scripts/metadata/check_subj_dwi_metadata.py
+++ b/snakedwi/workflow/scripts/metadata/check_subj_dwi_metadata.py
@@ -109,7 +109,7 @@ def set_sdc_method(
         if len(set(pe_dirs)) >= 2:  # Opp PE
             shell(f"touch {workflowopts}/sdc-topup")
         else:  # Single PE
-            shell(f"touch {workflowopts}/" f"sdc-{smk_config['sdc_method_alternate']}")
+            shell(f"touch {workflowopts}/sdc-{smk_config['sdc_method_alternate']}")
 
     else:
         shell(f"touch {workflowopts}/sdc-{smk_config['sdc_method']}")


### PR DESCRIPTION
As discussed in #54, the "optimal" SDC method functionality was reimplemented in that workflow (i.e., topup if 2+ PE directions, synthsr if 1 PE direction). This PR adds in the ability to change the default single PE method used - currently "synthsr" by passing the method choice through the `--sdc_method_alternate` flag.

I like the idea of having a priority list, but I'm not sure I see a practical use case for it without having to consider fail cases, unless there are alternate methods to topup

Will leave this as a draft for now until #54 has been reviewed.