### PR TITLE
Add versioning + PR/Issue/Contributing Docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+
+## Contributing to snakedwi
+
+Snakedwi python package dependencies are managed with Poetry 
+which you will need installed on your machine. You can find installation 
+instructions on the [Poetry website](https://python-poetry.org/).
+
+Snakedwi also has a few dependencies outside of Python, including popular 
+neuroimaging packages like ANTs, Freesurfer, FSL, MRtrix3, and others. We 
+strongly recommend using snakedwi with the `--use-singularity` flag, 
+which will pull and use the required containers, unless you are comfortable 
+using installing and using all of these tools yourself.
+
+## Setup the development environment
+
+Clone the repository and install all dependencies (including dev) with poetry:
+
+```bash
+git clone https://github.com/khanlab/snakedwi.git 
+cd snakedwi
+poetry install --with dev 
+```
+
+Poetry will automatically create a virtual environment. To customize where these 
+virtual environments are stored, see the poetry docs here
+
+Then, you can run snakedwi with:
+
+```bash
+poetry run snakedwi
+```
+
+or you can activate a virtual environment shell and run snakedwi directly:
+
+```bash
+poetry shell
+snakedwi
+```
+
+You can exit the poetry shell with `exit`
+
+## Running and fixing code format quality
+
+Snakedwi uses [poethepoet](https://github.com/nat-n/poethepoet) as a task 
+runner. You can see what commands are available by running:
+
+```bash
+poetry run poe 
+```
+
+We use a few tools, including `black`, `flake8`, `isort`, `snakefmt`, and 
+`yamlfix` to ensure formatting and style of our codebase is consistent. There 
+are two task runners you can use to check and fix your code, which can be 
+invoked with:
+
+```bash
+poetry run poe quality_check
+poetry run poe quality_fix
+```
+
+Note: If you are in a poetry shell, you do not need to prepend poetry run to the
+command.
+
+## Dry-run / testing your workflow
+
+Using Snakemake’s dry-run option (`--dry-run`/`-n`) is an easy way to verify any 
+changes made to the workflow are working correctly. The test_data folder 
+contains example BIDS datasets that are useful for verifying different workflow
+conditions. These dry-run tests are part of the automated GitHub actions that 
+are run for every commit.
+
+You can invoke the pre-configured task via `poethepoet` to perform a dry-run:
+
+```bash
+poetry run poe test
+```
+
+This performs a number of tests, involving different scenarios in which a user 
+may use snakedwi.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+## The problem
+
+Briefly describe the issue you are experiencing (or feature you want to see 
+added). If you received an error, please include the error message!
+
+## Steps to reproduce
+
+Please also include the steps you took so we can try to reproduce the error!
+
+## Screenshots
+
+If you have any helpful screenshots please include them!
+
+## Environment
+
+* `snakedwi` version (if applicable)
+* Operating system (e.g. Ubuntu 20.04, Windows 10)
+* Environment (e.g. Local, Docker, Singularity)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Proposed changes
+
+Describe the changes implemented in this pull request. If the changes fix a bug 
+or resolves a feature request, be sure to link the issue (and explain how the 
+changes address the issue). Be sure to select a label describing the PR (e.g. 
+maintenance).
+
+## Checklist
+
+Put an `x` in the boxes that apply. You can also fill these out after creating 
+the PR. If you are unsure about any of the choices, don't hesitate to ask!
+
+- [ ] Changes have been tested to ensure that fix is effective or that a 
+feature works.
+- [ ] Changes passes tests (e.g. `poetry run poe test`)
+- [ ] I have included necessary documentation or comments (as necessary)
+- [ ] Any dependent changes have been merged and published
+
+## Notes
+All PRs will undergo the unit testing before being reviewed. You may be 
+requested to explain or make additional changes before the PR is accepted.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,44 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  ## Changes
+
+  $CHANGES
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'major'
+      - 'breaking'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'maintenance'
+      - 'test'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+
+exclude-labels:
+  - skip_changelog
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'breaking'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'maintenance'
+      - 'bug'
+      - 'test'
+      - 'documentation'
+  default: patch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,44 +1,26 @@
-name-template: '$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+---
+name-template: $RESOLVED_VERSION
+tag-template: v$RESOLVED_VERSION
 template: |
   ## Changes
-
   $CHANGES
 categories:
-  - title: '🚀 Features'
-    labels:
-      - 'major'
-      - 'breaking'
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    labels:
-      - 'maintenance'
-      - 'test'
-  - title: '📝 Documentation'
-    labels:
-      - 'documentation'
-
-exclude-labels:
-  - skip_changelog
-
+  - title: 🚀 Features
+    labels: [major, breaking, enhancement]
+  - title: 🐛 Bug Fixes
+    labels: [bug]
+  - title: 🧰 Maintenance
+    labels: [maintenance, test]
+  - title: 📝 Documentation
+    labels: [documentation]
+exclude-labels: [skip_changelog]
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-
+change-title-escapes: \<*_&   # You can add  # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
-    labels:
-      - 'major'
+    labels: [major]
   minor:
-    labels:
-      - 'breaking'
-      - 'enhancement'
+    labels: [breaking, enhancement]
   patch:
-    labels:
-      - 'maintenance'
-      - 'bug'
-      - 'test'
-      - 'documentation'
+    labels: [maintenance, bug, test, documentation]
   default: patch

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,71 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Update changelog
+        uses: release-drafter/release-drafter@v5
+        id: release-drafter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get previous release version
+        run: |
+          echo "PREV_VER=$(cat pyproject.toml | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+\.[0-9]+\.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
+
+      - name: Get previous bump version
+        env:
+          PREV_VER: ${{ env.PREV_VER }}
+        run: |
+          if [[ "$PREV_VER" != *"-pre."* ]]; then
+            echo "OLD_BUMP=0" >> $GITHUB_ENV
+          else
+            echo "OLD_BUMP=$(echo $PREV_VER | cut -d '.' -f 4)" >> $GITHUB_ENV
+          fi
+
+      - name: Bump version
+        env:
+          BUMP_VER: ${{ env.OLD_BUMP }}
+        run: |
+          echo "NEW_BUMP=$(($BUMP_VER + 1))" >> $GITHUB_ENV
+
+      - name: Update version in pyproject
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: 'pyproject.toml'
+          find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: 'version = "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
+
+      - name: Update version in pipeline_description
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: 'snakedwi/pipeline_description.json'
+          find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: '"Version": "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
+
+      - name: Update version in config/snakebids.yml
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: 'snakedwi/config/snakebids.yml'
+          find: 'version: "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: 'version: "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
+
+      - name: Commit updates
+        env:
+          SNAKEBIDS_VERSION: ${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git diff-index --quiet HEAD || git commit -m "Bump version to $SNAKEBIDS_VERSION" -a
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tags: false

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,24 +1,21 @@
+---
 name: Bump version
 on:
   push:
-    branches:
-      - master
+    branches: [master]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-
       - name: Update changelog
         uses: release-drafter/release-drafter@v5
         id: release-drafter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Get previous release version
         run: |
           echo "PREV_VER=$(cat pyproject.toml | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+\.[0-9]+\.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
-
       - name: Get previous bump version
         env:
           PREV_VER: ${{ env.PREV_VER }}
@@ -28,42 +25,40 @@ jobs:
           else
             echo "OLD_BUMP=$(echo $PREV_VER | cut -d '.' -f 4)" >> $GITHUB_ENV
           fi
-
       - name: Bump version
         env:
           BUMP_VER: ${{ env.OLD_BUMP }}
         run: |
           echo "NEW_BUMP=$(($BUMP_VER + 1))" >> $GITHUB_ENV
-
       - name: Update version in pyproject
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'pyproject.toml'
-          find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
-          replace: 'version = "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
-
+          include: pyproject.toml
+          find: version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"
+          replace: version = "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP
+            }}"
       - name: Update version in pipeline_description
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'snakedwi/pipeline_description.json'
+          include: snakedwi/pipeline_description.json
           find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
-          replace: '"Version": "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
-
+          replace: '"Version": "${{ steps.release-drafter.outputs.name }}-pre.${{
+            env.NEW_BUMP }}"'
       - name: Update version in config/snakebids.yml
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'snakedwi/config/snakebids.yml'
+          include: snakedwi/config/snakebids.yml
           find: 'version: "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
-          replace: 'version: "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
-
+          replace: 'version: "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP
+            }}"'
       - name: Commit updates
         env:
-          SNAKEBIDS_VERSION: ${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}
+          SNAKEBIDS_VERSION: ${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP
+            }}
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git diff-index --quiet HEAD || git commit -m "Bump version to $SNAKEBIDS_VERSION" -a
-
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Deploy workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      comments:
+        description: "Comments"
+        required: false
+
+jobs:
+  release_changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print author
+        run: |
+          echo "Author: ${{ github.triggering_actor }}"
+          echo "Comments: ${{ github.event.inputs.comments }}"
+
+      - name: Extract branch name
+        shell: bash
+        id: extract_branch
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ steps.extract_branch.outputs.branch }}
+
+      - name: Draft change log
+        uses: release-drafter/release-drafter@v5
+        id: release-drafter
+        with:
+          commitish: ${{ steps.extract_branch.outputs.branch }}        
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set new release version
+        env:
+          RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
+        run: |
+          if [ ! -z "$RD_RELEASE" ]; then
+            echo "NEW_RELEASE=$RD_RELEASE" >> $GITHUB_ENV
+          else
+            echo "NEW_RELEASE=0.1.0" >> $GITHUB_ENV
+          fi
+
+      - name: Update version in pyproject.toml
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: 'pyproject.toml'
+          find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: 'version = "${{ env.NEW_RELEASE }}"'
+
+      - name: Update version in pipeline_description
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: 'snakedwi/pipeline_description.json'
+          find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: '"Version": "${{ env.NEW_RELEASE }}"'
+
+      - name: Update version in config/snakebids.yml
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: 'snakedwi/config/snakebids.yml'
+          find: 'version: "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: 'version: "${{ env.NEW_RELEASE }}"'
+
+ 
+      - name: Commit updates
+        env:
+          LATEST_VERSION: ${{ env.NEW_RELEASE }}
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git diff-index --quiet HEAD || git commit -m "Bump version to $LATEST_VERSION" -a
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish change log
+        uses: release-drafter/release-drafter@v5
+        with:
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,33 @@
+---
 name: Deploy workflow
-
 on:
   workflow_dispatch:
     inputs:
       comments:
-        description: "Comments"
+        description: Comments
         required: false
-
 jobs:
   release_changelog:
     runs-on: ubuntu-latest
-
     steps:
       - name: Print author
         run: |
           echo "Author: ${{ github.triggering_actor }}"
           echo "Comments: ${{ github.event.inputs.comments }}"
-
       - name: Extract branch name
         shell: bash
         id: extract_branch
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-
       - uses: actions/checkout@master
         with:
           ref: ${{ steps.extract_branch.outputs.branch }}
-
       - name: Draft change log
         uses: release-drafter/release-drafter@v5
         id: release-drafter
         with:
-          commitish: ${{ steps.extract_branch.outputs.branch }}        
+          commitish: ${{ steps.extract_branch.outputs.branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set new release version
         env:
           RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
@@ -43,28 +37,24 @@ jobs:
           else
             echo "NEW_RELEASE=0.1.0" >> $GITHUB_ENV
           fi
-
       - name: Update version in pyproject.toml
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'pyproject.toml'
-          find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
-          replace: 'version = "${{ env.NEW_RELEASE }}"'
-
+          include: pyproject.toml
+          find: version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"
+          replace: version = "${{ env.NEW_RELEASE }}"
       - name: Update version in pipeline_description
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'snakedwi/pipeline_description.json'
+          include: snakedwi/pipeline_description.json
           find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: '"Version": "${{ env.NEW_RELEASE }}"'
-
       - name: Update version in config/snakebids.yml
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'snakedwi/config/snakebids.yml'
+          include: snakedwi/config/snakebids.yml
           find: 'version: "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version: "${{ env.NEW_RELEASE }}"'
-
  
       - name: Commit updates
         env:
@@ -73,12 +63,10 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git diff-index --quiet HEAD || git commit -m "Bump version to $LATEST_VERSION" -a
-
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish change log
         uses: release-drafter/release-drafter@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
           include: snakedwi/config/snakebids.yml
           find: 'version: "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version: "${{ env.NEW_RELEASE }}"'
- 
       - name: Commit updates
         env:
           LATEST_VERSION: ${{ env.NEW_RELEASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version
+            }}
     #----------------------------------------------
     # install dependencies if cache does not exist
     #----------------------------------------------
@@ -118,6 +119,5 @@ jobs:
     #----------------------------------------------
     # Run tests
     #----------------------------------------------
-      - name: Test dry-run 
+      - name: Test dry-run
         run: poetry run poe test_dryrun
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019, Felix Mölder, Johannes Köster
+Copyright (c) 2020-2023 Ali Khan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snakedwi"
-version = "0.2.0-alpha"
+version = "0.2.0"
 description = "snakedwi - BIDS app and snakemake workflow for dwi pre-processing"
 authors = ["Ali Khan <alik@robarts.ca>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ find . -type f \\( \
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+line_length = 79
 
 [tool.ruff]
 builtins = [ "snakemake" ]

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -132,6 +132,15 @@ parse_args:
       - 'sdcflow'
       - 'synthsr'
       - 'none'
+
+  --sdc_method_alternate:
+    help: 'Set alternate method to be used for single phase encoding SDC when 
+          "--sdc_method" is set to "optimal", otherwise this flag is ignored.
+          (default: %(default)s)'
+    default: 'synthsr'
+    choices:
+      - 'sdcflow'
+      - 'synthsr'
           
   # Eddy options
   --use_eddy_s2v:

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -1,20 +1,15 @@
-bids_dir: 'test_data/bids_downsampled_1bzero' #for testing topup workflow
-#bids_dir: 'test_data/bids_downsampled_1bzero_1scan' #for testing synthsrsdc workflow
-
-output_dir: 'test_output/snakedwi_downsampled_1bzero'
+bids_dir: '/path/to/bids/dir' 
+output_dir: '/path/to/output/dir'
 
 #enable printing debug statements during parsing -- disable if generating dag visualization
 debug: False
 
-
 # boilerplate above
-
 derivatives: False
 
 #mappings from analysis_level to set of target rules or files
 analysis_levels: &analysis_levels
  - participant
-
 
 targets_by_analysis_level:
   participant:
@@ -209,6 +204,12 @@ parse_args:
     help: 'Number of iterations to use at each multi-resolution stage for dwi 
           to t1 rigid registration. (default: %(default)s)'
     default: '50x50'
+
+  # Workflow metadata
+  --version:
+    help: 'Print the version of snakedwi'
+    action: version
+    version: "0.2.0"
 
 #---- to update below this
 

--- a/snakedwi/config/snakebids.yml
+++ b/snakedwi/config/snakebids.yml
@@ -85,16 +85,11 @@ parse_args:
   --skip_denoise:
     help: 'Skip the denoising step of the workflow. By default, denoising is 
           performed if input diffusion data was acquired with at least 30 
-          drections. (default: %(default)s)'
+          directions. (default: %(default)s)'
 
   --derivatives:
     action: 'store_true'
     default: False
-
-  --no_topup:
-    help: 'Disable topup  (default: %(default)s)'
-    action: 'store_true'
-    default: False 
 
   # B0 masking options
   --masking_method:

--- a/snakedwi/pipeline_description.json
+++ b/snakedwi/pipeline_description.json
@@ -5,11 +5,10 @@
     "GeneratedBy": [
         {
             "Name": "snakedwi",
-            "Version": "0.2.0-alpha",
+            "Version": "0.2.0",
             "CodeURL": "http://github.com/akhanf/snakedwi",
             "Author": "Ali R. Khan",
             "AuthorEmail": "alik@robarts.ca"
- 
         }
     ]
 }

--- a/snakedwi/workflow/scripts/diffusion/sdc/sdcflows_syn.py
+++ b/snakedwi/workflow/scripts/diffusion/sdc/sdcflows_syn.py
@@ -9,7 +9,10 @@ import nibabel as nib
 import nipype.interfaces.io as nio
 import nipype.pipeline.engine as pe
 from nipype import Workflow
-from sdcflows.workflows.fit.syn import init_syn_preprocessing_wf, init_syn_sdc_wf
+from sdcflows.workflows.fit.syn import (
+    init_syn_preprocessing_wf,
+    init_syn_sdc_wf,
+)
 
 
 def sdcflows_syn(

--- a/snakedwi/workflow/scripts/diffusion/sdc/sdcflows_syn.py
+++ b/snakedwi/workflow/scripts/diffusion/sdc/sdcflows_syn.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import json
 import tempfile
 from glob import glob

--- a/snakedwi/workflow/scripts/metadata/check_subj_dwi_metadata.py
+++ b/snakedwi/workflow/scripts/metadata/check_subj_dwi_metadata.py
@@ -109,7 +109,7 @@ def set_sdc_method(
         if len(set(pe_dirs)) >= 2:  # Opp PE
             shell(f"touch {workflowopts}/sdc-topup")
         else:  # Single PE
-            shell(f"touch {workflowopts}/sdc-synthsr")
+            shell(f"touch {workflowopts}/" f"sdc-{smk_config['sdc_method_alternate']}")
 
     else:
         shell(f"touch {workflowopts}/sdc-{smk_config['sdc_method']}")

--- a/snakedwi/workflow/scripts/metadata/check_subj_dwi_metadata.py
+++ b/snakedwi/workflow/scripts/metadata/check_subj_dwi_metadata.py
@@ -109,7 +109,7 @@ def set_sdc_method(
         if len(set(pe_dirs)) >= 2:  # Opp PE
             shell(f"touch {workflowopts}/sdc-topup")
         else:  # Single PE
-            shell(f"touch {workflowopts}/" f"sdc-{smk_config['sdc_method_alternate']}")
+            shell(f"touch {workflowopts}/sdc-{smk_config['sdc_method_alternate']}")
 
     else:
         shell(f"touch {workflowopts}/sdc-{smk_config['sdc_method']}")


### PR DESCRIPTION
Based off of branch used for #55, this PR adds in the github actions for versioning, as well as some templates for PRs/issues and documents for contributing.

### Versioning

Originally wanted to make use of the triggers from Github itself, but realized that it would run into the problem of keeping the files in the repo up to date with the tagged released version. Opted to use a similar workflow as hippunfold for this instead (though can also look into poetry dynamic versioning). Also adds in a CLI argument to print the version.