### PR TITLE
Fix bug where workflow fails when there are no acq, run or dir entities in the dwi file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ report.html
 
 # Linters and tools
 .ruff_cache
+
+# other
+*jobs/

--- a/snakedwi/workflow/rules/setup.smk
+++ b/snakedwi/workflow/rules/setup.smk
@@ -42,9 +42,13 @@ input_zip_lists = inputs.input_zip_lists
 input_path = inputs.input_path
 
 # if no acquisiton, run or direction specified for diffusion image add acquisition wildcard to input_wildcards and add 'notspecified' for acquisition in corresponding images in input_zip_lists
-if not any([ item in ['acq','run','dir'] for item in list(input_wildcards['dwi'].keys())]):
-    input_wildcards['dwi']['acq'] = '{acquisition}'
-    input_zip_lists['dwi']['acquisition'] = ['notspecified']*len(input_zip_lists['dwi']['subject'])
+if not any(
+    [item in ["acq", "run", "dir"] for item in list(input_wildcards["dwi"].keys())]
+):
+    input_wildcards["dwi"]["acq"] = "{acquisition}"
+    input_zip_lists["dwi"]["acquisition"] = ["notspecified"] * len(
+        input_zip_lists["dwi"]["subject"]
+    )
 
 root = os.path.join(config["root"], "snakedwi")
 work = os.path.join(config["root"], "work")

--- a/snakedwi/workflow/rules/setup.smk
+++ b/snakedwi/workflow/rules/setup.smk
@@ -42,7 +42,7 @@ input_zip_lists = inputs.input_zip_lists
 input_path = inputs.input_path
 
 # if no acquisiton, run or direction specified for diffusion image add acquisition wildcard to input_wildcards and add 'notspecified' for acquisition in corresponding images in input_zip_lists
-if not all([ item in ['acquisition','run','direction'] for item in input_wildcards['dwi'].keys()]):
+if not any([ item in ['acq','run','dir'] for item in list(input_wildcards['dwi'].keys())]):
     input_wildcards['dwi']['acq'] = '{acquisition}'
     input_zip_lists['dwi']['acquisition'] = ['notspecified']*len(input_zip_lists['dwi']['subject'])
 

--- a/snakedwi/workflow/rules/setup.smk
+++ b/snakedwi/workflow/rules/setup.smk
@@ -41,6 +41,11 @@ subj_wildcards = inputs.subj_wildcards
 input_zip_lists = inputs.input_zip_lists
 input_path = inputs.input_path
 
+# if no acquisiton, run or direction specified for diffusion image add acquisition wildcard to input_wildcards and add 'notspecified' for acquisition in corresponding images in input_zip_lists
+if not all([ item in ['acquisition','run','direction'] for item in input_wildcards['dwi'].keys()]):
+    input_wildcards['dwi']['acq'] = '{acquisition}'
+    input_zip_lists['dwi']['acquisition'] = ['notspecified']*len(input_zip_lists['dwi']['subject'])
+
 root = os.path.join(config["root"], "snakedwi")
 work = os.path.join(config["root"], "work")
 qc = os.path.join(config["root"], "qc")


### PR DESCRIPTION
## Proposed changes

Fixing bug described in #57 when `acq`, `run` or `dir` are not included in input dwi file name. In the setup.smk file, add an if statement to check if `acq`, `run` or `dir` are in `input_wildcards` and if not then a dummy wildcard for `acquisition` is added to `input_wildcards` and set to `notspecified` in `input_zip_lists`.

## Checklist

- [x] Changes have been tested to ensure that fix is effective or that a 
feature works.
- [x] Changes passes tests (e.g. `poetry run poe test`)
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published
